### PR TITLE
fix: include workflows/ in Docker image for Explore sync task

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -82,6 +82,9 @@ jobs:
           kubectl get nodes
           kubectl get svc -n acedatacloud
 
+      - name: Copy workflows into API build context
+        run: cp -r ../workflows ../api/workflows
+
       - name: Build Docker images
         env:
           BUILD_NUMBER: ${{ env.BUILD_NUMBER }}

--- a/api/tasks/import_acedatacloud_workflow_templates_task.py
+++ b/api/tasks/import_acedatacloud_workflow_templates_task.py
@@ -13,7 +13,10 @@ from models.model import RecommendedApp, Site
 
 logger = logging.getLogger(__name__)
 
-WORKFLOWS_DIR = Path(__file__).resolve().parent.parent.parent / "workflows"
+_API_DIR = Path(__file__).resolve().parent.parent
+# In Docker the CI copies workflows/ into api/workflows/ (inside the build context).
+# In local dev the original workflows/ lives one level above api/.
+WORKFLOWS_DIR = _API_DIR / "workflows" if (_API_DIR / "workflows").is_dir() else _API_DIR.parent / "workflows"
 REDIS_KEY_PREFIX = "acedatacloud_workflow_imported:"
 REDIS_EXPIRY = 365 * 24 * 3600  # 1 year
 


### PR DESCRIPTION
## Problem

PR #65 added the Explore sync task and hybrid mode, but the `workflows/` directory at the repo root was never included in the Docker image. The Docker build context is `api/`, so anything outside `api/` is invisible to Docker.

**Runtime evidence** from the running worker pod:
```
No workflow files found, skipping.
```

Container verification:
```
/app/workflows/ -> does not exist
/app/api/workflows/ -> does not exist
RecommendedApp records: 0
```

Both the Celery beat sync task (`sync_acedatacloud_explore_task`) and the login-triggered import task call `get_workflow_files()`, which returns `[]` because the YAML files are missing from the container.

## Fix

1. **CI (`auto-deploy.yml`)**: Copy `workflows/` into `api/workflows/` before `docker compose build`, so the files enter the Docker build context
2. **Python path fallback**: `WORKFLOWS_DIR` now checks `api/workflows/` first (Docker) and falls back to `../workflows/` (local dev)

## Verification

After deploy, the worker log should show:
```
Start sync AceDataCloud Explore apps.
Sync AceDataCloud Explore done: registered=13
```

And `/explore` should display AceDataCloud workflow templates.
