### PR TITLE
feat: update AceDataCloud plugin params to match latest OpenAPI specs

### DIFF
--- a/plugins/hailuo/tools/hailuo_generate.yaml
+++ b/plugins/hailuo/tools/hailuo_generate.yaml
@@ -73,6 +73,8 @@ parameters:
         label: { en_US: minimax-t2v, zh_Hans: 文生视频 }
       - value: minimax-i2v
         label: { en_US: minimax-i2v, zh_Hans: 图生视频 }
+      - value: minimax-i2v-director
+        label: { en_US: minimax-i2v-director, zh_Hans: 图生视频(导演模式) }
   - name: first_image_url
     type: string
     required: false

--- a/plugins/kling/tools/kling_generate.yaml
+++ b/plugins/kling/tools/kling_generate.yaml
@@ -99,9 +99,9 @@ parameters:
       en_US: Model
       zh_Hans: 模型
     human_description:
-      en_US: Optional model name (e.g., kling-v2-5-turbo).
-      zh_Hans: 可选模型名称（如 kling-v2-5-turbo）。
-    llm_description: "Optional. Examples: kling-v1, kling-v1-6, kling-v2-master, kling-v2-1-master, kling-v2-5-turbo."
+      en_US: Optional model name (e.g., kling-v2-5-turbo, kling-video-o1).
+      zh_Hans: 可选模型名称（如 kling-v2-5-turbo、kling-video-o1）。
+    llm_description: "Optional. Examples: kling-v1, kling-v1-6, kling-v2-master, kling-v2-1-master, kling-v2-5-turbo, kling-video-o1."
     form: form
   - name: mode
     type: select

--- a/plugins/midjourney/tools/acedata_client.py
+++ b/plugins/midjourney/tools/acedata_client.py
@@ -205,6 +205,10 @@ def build_midjourney_imagine_payload(tool_parameters: dict[str, Any]) -> dict[st
     if isinstance(application_id, str) and application_id.strip():
         payload["application_id"] = application_id.strip()
 
+    mask = tool_parameters.get("mask")
+    if isinstance(mask, str) and mask.strip():
+        payload["mask"] = mask.strip()
+
     return payload
 
 

--- a/plugins/midjourney/tools/midjourney_imagine.yaml
+++ b/plugins/midjourney/tools/midjourney_imagine.yaml
@@ -95,6 +95,15 @@ parameters:
       zh_Hans: 将 2x2 预览图拆分为单张（如支持）。
     llm_description: Optional boolean.
     form: form
+  - name: mask
+    type: string
+    required: false
+    label: { en_US: Mask URL, zh_Hans: 蒙版链接 }
+    human_description:
+      en_US: Optional mask image URL for variation_region action.
+      zh_Hans: 可选蒙版图片链接，用于 variation_region 操作。
+    llm_description: Optional. Provide a mask image URL when action is variation_region.
+    form: form
   - name: callback_url
     type: string
     required: false

--- a/plugins/nano-banana/tools/nano_banana_edit.yaml
+++ b/plugins/nano-banana/tools/nano_banana_edit.yaml
@@ -79,6 +79,10 @@ parameters:
         label:
           en_US: nano-banana (default)
           zh_Hans: nano-banana（默认）
+      - value: nano-banana-2
+        label:
+          en_US: nano-banana-2
+          zh_Hans: nano-banana-2
       - value: nano-banana-pro
         label:
           en_US: nano-banana-pro

--- a/plugins/nano-banana/tools/nano_banana_generate.yaml
+++ b/plugins/nano-banana/tools/nano_banana_generate.yaml
@@ -64,6 +64,10 @@ parameters:
         label:
           en_US: nano-banana (default)
           zh_Hans: nano-banana（默认）
+      - value: nano-banana-2
+        label:
+          en_US: nano-banana-2
+          zh_Hans: nano-banana-2
       - value: nano-banana-pro
         label:
           en_US: nano-banana-pro

--- a/plugins/seedance/tools/acedata_client.py
+++ b/plugins/seedance/tools/acedata_client.py
@@ -67,6 +67,13 @@ class AceDataSeedanceClient:
         first_frame_url: str | None = None,
         last_frame_url: str | None = None,
         reference_image_urls: list[str] | None = None,
+        resolution: str | None = None,
+        ratio: str | None = None,
+        duration: int | None = None,
+        seed: int | None = None,
+        camerafixed: bool | None = None,
+        watermark: bool | None = None,
+        generate_audio: bool | None = None,
         callback_url: str | None = None,
         return_last_frame: bool | None = None,
         service_tier: str | None = None,
@@ -86,6 +93,20 @@ class AceDataSeedanceClient:
         payload: dict[str, Any] = {"content": content}
         if model:
             payload["model"] = model
+        if resolution:
+            payload["resolution"] = resolution
+        if ratio:
+            payload["ratio"] = ratio
+        if duration is not None:
+            payload["duration"] = duration
+        if seed is not None:
+            payload["seed"] = seed
+        if camerafixed is not None:
+            payload["camerafixed"] = camerafixed
+        if watermark is not None:
+            payload["watermark"] = watermark
+        if generate_audio is not None:
+            payload["generate_audio"] = generate_audio
         if callback_url:
             payload["callback_url"] = callback_url
         if return_last_frame is not None:

--- a/plugins/seedance/tools/seedance_generate.py
+++ b/plugins/seedance/tools/seedance_generate.py
@@ -68,6 +68,44 @@ class SeedanceGenerateVideoTool(Tool):
             else None
         )
 
+        resolution = tool_parameters.get("resolution")
+        resolution = (
+            resolution.strip()
+            if isinstance(resolution, str) and resolution.strip()
+            else None
+        )
+
+        ratio = tool_parameters.get("ratio")
+        ratio = (
+            ratio.strip()
+            if isinstance(ratio, str) and ratio.strip()
+            else None
+        )
+
+        duration = tool_parameters.get("duration")
+        if duration is not None:
+            if isinstance(duration, bool) or not isinstance(duration, (int, float)):
+                raise ValueError("`duration` must be a number.")
+            duration = int(duration)
+
+        seed = tool_parameters.get("seed")
+        if seed is not None:
+            if isinstance(seed, bool) or not isinstance(seed, (int, float)):
+                raise ValueError("`seed` must be a number.")
+            seed = int(seed)
+
+        camerafixed = tool_parameters.get("camerafixed")
+        if camerafixed is not None and not isinstance(camerafixed, bool):
+            raise ValueError("`camerafixed` must be a boolean.")
+
+        watermark = tool_parameters.get("watermark")
+        if watermark is not None and not isinstance(watermark, bool):
+            raise ValueError("`watermark` must be a boolean.")
+
+        generate_audio = tool_parameters.get("generate_audio")
+        if generate_audio is not None and not isinstance(generate_audio, bool):
+            raise ValueError("`generate_audio` must be a boolean.")
+
         client = AceDataSeedanceClient(
             bearer_token=str(self.runtime.credentials["acedata_bearer_token"])
         )
@@ -78,6 +116,13 @@ class SeedanceGenerateVideoTool(Tool):
                 first_frame_url=first_frame_url,
                 last_frame_url=last_frame_url,
                 reference_image_urls=reference_image_urls or None,
+                resolution=resolution,
+                ratio=ratio,
+                duration=duration,
+                seed=seed,
+                camerafixed=camerafixed,
+                watermark=watermark,
+                generate_audio=generate_audio,
                 return_last_frame=return_last_frame,
                 service_tier=service_tier,
                 execution_expires_after=execution_expires_after,

--- a/plugins/seedance/tools/seedance_generate.yaml
+++ b/plugins/seedance/tools/seedance_generate.yaml
@@ -102,6 +102,105 @@ parameters:
       type: array
       items:
         type: string
+  - name: resolution
+    type: select
+    required: false
+    label:
+      en_US: Resolution
+      zh_Hans: 分辨率
+    human_description:
+      en_US: Optional output resolution (480p/720p/1080p).
+      zh_Hans: 可选输出分辨率（480p/720p/1080p）。
+    llm_description: Optional. Choose 480p, 720p, or 1080p.
+    form: form
+    options:
+      - value: 480p
+        label: { en_US: 480p, zh_Hans: 480p }
+      - value: 720p
+        label: { en_US: 720p, zh_Hans: 720p }
+      - value: 1080p
+        label: { en_US: 1080p, zh_Hans: 1080p }
+  - name: ratio
+    type: select
+    required: false
+    label:
+      en_US: Aspect Ratio
+      zh_Hans: 画面比例
+    human_description:
+      en_US: Optional output aspect ratio. Default is 16:9.
+      zh_Hans: 可选输出画面比例，默认 16:9。
+    llm_description: Optional. Choose an aspect ratio.
+    form: form
+    options:
+      - value: "16:9"
+        label: { en_US: "16:9", zh_Hans: "16:9" }
+      - value: "4:3"
+        label: { en_US: "4:3", zh_Hans: "4:3" }
+      - value: "1:1"
+        label: { en_US: "1:1", zh_Hans: "1:1" }
+      - value: "3:4"
+        label: { en_US: "3:4", zh_Hans: "3:4" }
+      - value: "9:16"
+        label: { en_US: "9:16", zh_Hans: "9:16" }
+      - value: "21:9"
+        label: { en_US: "21:9", zh_Hans: "21:9" }
+      - value: adaptive
+        label: { en_US: adaptive, zh_Hans: adaptive }
+  - name: duration
+    type: number
+    required: false
+    label:
+      en_US: Duration (seconds)
+      zh_Hans: 时长（秒）
+    human_description:
+      en_US: Optional video duration in seconds (2-12, varies by model).
+      zh_Hans: 可选视频时长，秒（2-12，因模型而异）。
+    llm_description: Optional. Integer seconds, range 2-12.
+    form: form
+  - name: seed
+    type: number
+    required: false
+    label:
+      en_US: Seed
+      zh_Hans: 随机种子
+    human_description:
+      en_US: Optional seed for reproducibility (-1 to 4294967295).
+      zh_Hans: 可选随机种子（-1 到 4294967295）。
+    llm_description: Optional. Integer seed value.
+    form: form
+  - name: camerafixed
+    type: boolean
+    required: false
+    label:
+      en_US: Camera Fixed
+      zh_Hans: 固定镜头
+    human_description:
+      en_US: Optional. Fix camera position during generation.
+      zh_Hans: 可选。生成时固定镜头位置。
+    llm_description: Optional. Set true to lock camera.
+    form: form
+  - name: watermark
+    type: boolean
+    required: false
+    label:
+      en_US: Watermark
+      zh_Hans: 水印
+    human_description:
+      en_US: Optional. Add watermark or not.
+      zh_Hans: 可选，是否添加水印。
+    llm_description: Optional.
+    form: form
+  - name: generate_audio
+    type: boolean
+    required: false
+    label:
+      en_US: Generate Audio
+      zh_Hans: 生成音频
+    human_description:
+      en_US: Optional. Generate audio for the video (only 1.5-pro model).
+      zh_Hans: 可选。为视频生成音频（仅 1.5-pro 模型支持）。
+    llm_description: Optional. Only supported by doubao-seedance-1-5-pro-251215.
+    form: form
   - name: return_last_frame
     type: boolean
     required: false

--- a/plugins/sora/tools/acedata_client.py
+++ b/plugins/sora/tools/acedata_client.py
@@ -63,6 +63,7 @@ class AceDataSoraClient:
         character_url: str | None = None,
         character_start: float | None = None,
         character_end: float | None = None,
+        version: str | None = None,
         callback_url: str | None = None,
         timeout_s: int = 1860,
     ) -> AceDataSoraVideosResult:
@@ -81,6 +82,8 @@ class AceDataSoraClient:
             payload["character_start"] = character_start
         if character_end is not None:
             payload["character_end"] = character_end
+        if version:
+            payload["version"] = version
         if callback_url:
             payload["callback_url"] = callback_url
 

--- a/plugins/sora/tools/sora_generate.py
+++ b/plugins/sora/tools/sora_generate.py
@@ -54,6 +54,13 @@ class SoraGenerateVideoTool(Tool):
         if character_end is not None and not isinstance(character_end, (int, float)):
             raise ValueError("`character_end` must be a number.")
 
+        version = tool_parameters.get("version")
+        version = (
+            version.strip()
+            if isinstance(version, str) and version.strip()
+            else None
+        )
+
         callback_url = tool_parameters.get("callback_url")
         callback_url = (
             callback_url.strip()
@@ -76,6 +83,7 @@ class SoraGenerateVideoTool(Tool):
                 character_url=character_url,
                 character_start=float(character_start) if character_start is not None else None,
                 character_end=float(character_end) if character_end is not None else None,
+                version=version,
                 callback_url=callback_url,
                 timeout_s=timeout_s,
             )

--- a/plugins/sora/tools/sora_generate.yaml
+++ b/plugins/sora/tools/sora_generate.yaml
@@ -84,6 +84,28 @@ parameters:
         label: { en_US: "15", zh_Hans: "15" }
       - value: 25
         label: { en_US: "25", zh_Hans: "25" }
+      - value: 4
+        label: { en_US: "4", zh_Hans: "4" }
+      - value: 8
+        label: { en_US: "8", zh_Hans: "8" }
+      - value: 12
+        label: { en_US: "12", zh_Hans: "12" }
+  - name: version
+    type: select
+    required: false
+    label:
+      en_US: API Version
+      zh_Hans: API 版本
+    human_description:
+      en_US: Optional API version. Default is 1.0. Version 2.0 supports pixel-based sizing.
+      zh_Hans: 可选 API 版本，默认 1.0。2.0 支持像素级尺寸。
+    llm_description: Optional. Use 1.0 (default) or 2.0. Version 2.0 supports pixel-based size like 720x1280.
+    form: form
+    options:
+      - value: "1.0"
+        label: { en_US: "1.0 (default)", zh_Hans: "1.0（默认）" }
+      - value: "2.0"
+        label: { en_US: "2.0", zh_Hans: "2.0" }
   - name: size
     type: select
     required: false
@@ -91,15 +113,23 @@ parameters:
       en_US: Size
       zh_Hans: 清晰度
     human_description:
-      en_US: Optional output size.
-      zh_Hans: 可选输出清晰度。
-    llm_description: Optional. Choose small or large.
+      en_US: Optional output size. Use small/large for v1.0, or pixel format (e.g. 720x1280) for v2.0.
+      zh_Hans: 可选输出尺寸。v1.0 用 small/large，v2.0 用像素格式（如 720x1280）。
+    llm_description: Optional. small/large for v1.0; pixel formats like 720x1280, 1280x720, 1024x1792, 1792x1024 for v2.0.
     form: form
     options:
       - value: small
         label: { en_US: small, zh_Hans: small }
       - value: large
         label: { en_US: large, zh_Hans: large }
+      - value: 720x1280
+        label: { en_US: 720x1280, zh_Hans: 720x1280 }
+      - value: 1280x720
+        label: { en_US: 1280x720, zh_Hans: 1280x720 }
+      - value: 1024x1792
+        label: { en_US: 1024x1792, zh_Hans: 1024x1792 }
+      - value: 1792x1024
+        label: { en_US: 1792x1024, zh_Hans: 1792x1024 }
   - name: orientation
     type: select
     required: false

--- a/plugins/suno/tools/suno_generate_audios.py
+++ b/plugins/suno/tools/suno_generate_audios.py
@@ -69,6 +69,18 @@ class SunoGenerateAudiosTool(Tool):
         if vocal_gender is not None and vocal_gender not in {"f", "m"}:
             raise ValueError("`vocal_gender` must be 'f' or 'm'.")
 
+        variation_category = tool_parameters.get("variation_category")
+        variation_category = (
+            variation_category.strip()
+            if isinstance(variation_category, str) and variation_category.strip()
+            else None
+        )
+        if variation_category is not None and variation_category not in {"high", "normal", "subtle"}:
+            raise ValueError("`variation_category` must be 'high', 'normal', or 'subtle'.")
+
+        weirdness = parse_optional_float(tool_parameters.get("weirdness"), field="weirdness")
+        style_influence = parse_optional_float(tool_parameters.get("style_influence"), field="style_influence")
+
         callback_url = tool_parameters.get("callback_url")
         callback_url = (
             callback_url.strip()
@@ -93,6 +105,7 @@ class SunoGenerateAudiosTool(Tool):
             "concat",
             "remaster",
             "replace_section",
+            "mashup",
         }
         if action in actions_requiring_audio_id and not audio_id:
             raise ValueError(f"`audio_id` is required when action is {action}.")
@@ -126,6 +139,12 @@ class SunoGenerateAudiosTool(Tool):
             payload["persona_id"] = persona_id
         if vocal_gender:
             payload["vocal_gender"] = vocal_gender
+        if variation_category:
+            payload["variation_category"] = variation_category
+        if weirdness is not None:
+            payload["weirdness"] = weirdness
+        if style_influence is not None:
+            payload["style_influence"] = style_influence
         if callback_url:
             payload["callback_url"] = callback_url
 

--- a/plugins/suno/tools/suno_generate_audios.yaml
+++ b/plugins/suno/tools/suno_generate_audios.yaml
@@ -32,9 +32,9 @@ parameters:
     required: true
     label: { en_US: Action, zh_Hans: 行为 }
     human_description:
-      en_US: Generation action, e.g. generate/extend/cover/stems/all_stems/concat/remaster.
-      zh_Hans: 生成行为，如 generate/extend/cover/stems/all_stems/concat/remaster。
-    llm_description: Required. Typical values are generate, extend, upload_extend, cover, upload_cover, stems, all_stems, concat, remaster.
+      en_US: Generation action, e.g. generate/extend/cover/stems/all_stems/concat/remaster/mashup/replace_section/underpainting/overpainting/samples.
+      zh_Hans: 生成行为，如 generate/extend/cover/stems/all_stems/concat/remaster/mashup/replace_section/underpainting/overpainting/samples。
+    llm_description: Required. Typical values are generate, extend, upload_extend, cover, upload_cover, stems, all_stems, concat, remaster, artist_consistency, artist_consistency_vox, replace_section, underpainting, overpainting, mashup, samples.
     form: form
   - name: prompt
     type: string
@@ -145,6 +145,40 @@ parameters:
         label: { en_US: Female, zh_Hans: 女声 }
       - value: m
         label: { en_US: Male, zh_Hans: 男声 }
+  - name: variation_category
+    type: select
+    required: false
+    label: { en_US: Variation Category, zh_Hans: 变奏类别 }
+    human_description:
+      en_US: Optional. Variation intensity for v5+ models (high/normal/subtle).
+      zh_Hans: 可选。v5+ 模型变奏强度（high/normal/subtle）。
+    llm_description: Optional. Only for chirp-v5+. Controls variation intensity.
+    form: form
+    options:
+      - value: high
+        label: { en_US: high, zh_Hans: 高 }
+      - value: normal
+        label: { en_US: normal, zh_Hans: 正常 }
+      - value: subtle
+        label: { en_US: subtle, zh_Hans: 轻微 }
+  - name: weirdness
+    type: number
+    required: false
+    label: { en_US: Weirdness, zh_Hans: 奇特度 }
+    human_description:
+      en_US: Optional. 0-1, controls generation weirdness.
+      zh_Hans: 可选。0-1，控制生成奇特度。
+    llm_description: Optional. Range 0-1.
+    form: form
+  - name: style_influence
+    type: number
+    required: false
+    label: { en_US: Style Influence, zh_Hans: 风格影响 }
+    human_description:
+      en_US: Optional. 0-1, controls style influence strength.
+      zh_Hans: 可选。0-1，控制风格影响强度。
+    llm_description: Optional. Range 0-1.
+    form: form
   - name: callback_url
     type: string
     required: false

--- a/plugins/veo/tools/acedata_client.py
+++ b/plugins/veo/tools/acedata_client.py
@@ -61,6 +61,7 @@ class AceDataVeoClient:
         image_urls: list[str] | None = None,
         video_id: str | None = None,
         aspect_ratio: str | None = None,
+        resolution: str | None = None,
         translation: bool | None = None,
         callback_url: str | None = None,
         timeout_s: int = 1800,
@@ -76,6 +77,8 @@ class AceDataVeoClient:
             payload["video_id"] = video_id
         if aspect_ratio:
             payload["aspect_ratio"] = aspect_ratio
+        if resolution:
+            payload["resolution"] = resolution
         if translation is not None:
             payload["translation"] = translation
         if callback_url:

--- a/plugins/veo/tools/veo_generate.py
+++ b/plugins/veo/tools/veo_generate.py
@@ -36,6 +36,13 @@ class VeoGenerateVideoTool(Tool):
             else None
         )
 
+        resolution = tool_parameters.get("resolution")
+        resolution = (
+            resolution.strip()
+            if isinstance(resolution, str) and resolution.strip()
+            else None
+        )
+
         translation = tool_parameters.get("translation")
         if translation is not None and not isinstance(translation, bool):
             raise ValueError("`translation` must be a boolean.")
@@ -68,6 +75,7 @@ class VeoGenerateVideoTool(Tool):
                 image_urls=image_urls or None,
                 video_id=video_id,
                 aspect_ratio=aspect_ratio,
+                resolution=resolution,
                 translation=translation,
                 callback_url=callback_url,
                 timeout_s=1800,

--- a/plugins/veo/tools/veo_generate.yaml
+++ b/plugins/veo/tools/veo_generate.yaml
@@ -107,8 +107,26 @@ parameters:
     human_description:
       en_US: Optional model name. Default is veo2-fast.
       zh_Hans: 可选模型名称，不填则默认为 veo2-fast。
-    llm_description: "Optional. Examples: veo2-fast, veo2, veo3-fast, veo3, veo31-fast, veo31."
+    llm_description: "Optional. Examples: veo2-fast, veo2, veo3-fast, veo3, veo31-fast, veo31, veo31-fast-ingredient."
     form: form
+  - name: resolution
+    type: select
+    required: false
+    label:
+      en_US: Resolution
+      zh_Hans: 分辨率
+    human_description:
+      en_US: Optional output resolution.
+      zh_Hans: 可选输出分辨率。
+    llm_description: Optional. Choose 4k, 1080p, or gif.
+    form: form
+    options:
+      - value: 4k
+        label: { en_US: 4k, zh_Hans: 4k }
+      - value: 1080p
+        label: { en_US: 1080p, zh_Hans: 1080p }
+      - value: gif
+        label: { en_US: gif, zh_Hans: gif }
   - name: aspect_ratio
     type: select
     required: false


### PR DESCRIPTION
Update 8 AceDataCloud Dify plugins to match latest OpenAPI specs. Added missing params and models for Suno, Seedance, Veo, Nano-Banana, Hailuo, Sora, Kling, Midjourney.