### PR TITLE
chore(k8s): fix dify-plugin-daemon OOM + right-size dify-api requests

### DIFF
--- a/deploy/production/deployment/dify-api.yml
+++ b/deploy/production/deployment/dify-api.yml
@@ -237,8 +237,8 @@ spec:
             cpu: 500m
             memory: 1Gi
           requests:
-            cpu: 300m
-            memory: 512Mi
+            cpu: 100m
+            memory: 256Mi
         securityContext:
           privileged: false
         volumeMounts:

--- a/deploy/production/deployment/dify-plugin-daemon.yml
+++ b/deploy/production/deployment/dify-plugin-daemon.yml
@@ -6,7 +6,7 @@ metadata:
   name: dify-plugin-daemon
   namespace: acedatacloud
 spec:
-  replicas: 3
+  replicas: 2
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -110,10 +110,10 @@ spec:
           resources:
             limits:
               cpu: "2"
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 500m
-              memory: 1Gi
+              memory: 2500Mi
           securityContext:
             privileged: false
           startupProbe:


### PR DESCRIPTION
## Why

Two Dify deployments needed tuning after the cluster-pressure audit:

### `dify-plugin-daemon` — fix chronic OOM

Currently only **1/3 pods are Ready** because the daemon is consistently OOMKilled. `kubectl top` shows actual memory usage ~**4065Mi** against a **4Gi limit** — the kernel keeps killing it at the limit. Meanwhile the **1Gi request** was so far below reality that pods couldn't even schedule on most nodes.

```diff
       resources:
         limits:
           cpu: "2"
-          memory: 4Gi
+          memory: 5Gi
         requests:
           cpu: 500m
-          memory: 1Gi
+          memory: 2500Mi
```

Also `replicas: 3 -> 2`. Three pods all trying to OOM-recover is worse than two stable pods.

### `dify-api` — right-size CPU + memory request

`kubectl top` shows actual usage ~30-50m CPU / ~250Mi memory against `300m / 512Mi` requests — 6-10× over-reserved.

```diff
       resources:
         limits:
           cpu: 500m
           memory: 1Gi
         requests:
-          cpu: 300m
-          memory: 512Mi
+          cpu: 100m
+          memory: 256Mi
```

Limits are unchanged so peak headroom is preserved.

## Impact

- **Stops the plugin-daemon OOM crashloop** — biggest user-facing win on the cluster right now.
- Net cluster change: plugin-daemon adds ~3Gi memory request (2 pods × +1.5Gi) but frees a 3rd replica (-2.5Gi after change) → essentially neutral on memory while finally being _accurate_ to actual usage; dify-api frees ~400m CPU + 512Mi memory.
- No env or app-level changes.

## Rollback

`git revert` if the higher memory request prevents scheduling — but the cluster has plenty of memory headroom now (post acedatacloud-deployment cleanup).
