### PR TITLE
chore(flux): align model list with TTApi backend

### DIFF
--- a/api/workflows/ai-logo-designer.yml
+++ b/api/workflows/ai-logo-designer.yml
@@ -243,7 +243,7 @@ workflow:
             value: 'Extract LOGO1 prompt from: {{#designer_llm.text#}}'
           model:
             type: mixed
-            value: flux-pro-1.1
+            value: flux-pro
           size:
             type: mixed
             value: 1024x1024
@@ -276,7 +276,7 @@ workflow:
             value: 'Extract LOGO2 prompt from: {{#designer_llm.text#}}'
           model:
             type: mixed
-            value: flux-pro-1.1
+            value: flux-pro
           size:
             type: mixed
             value: 1024x1024
@@ -309,7 +309,7 @@ workflow:
             value: 'Extract LOGO3 prompt from: {{#designer_llm.text#}}'
           model:
             type: mixed
-            value: flux-pro-1.1
+            value: flux-pro
           size:
             type: mixed
             value: 1024x1024

--- a/api/workflows/ai-marketing-suite.yml
+++ b/api/workflows/ai-marketing-suite.yml
@@ -234,7 +234,7 @@ workflow:
             value: '{{#strategist_llm.text#}}'
           model:
             type: mixed
-            value: flux-pro-1.1
+            value: flux-pro
           size:
             type: mixed
             value: 1920x1080

--- a/api/workflows/ai-storyboard-video.yml
+++ b/api/workflows/ai-storyboard-video.yml
@@ -334,7 +334,7 @@ workflow:
             value: 'Extract SCENE 1 IMAGE_PROMPT from: {{#storyboard_llm.text#}}'
           model:
             type: mixed
-            value: flux-pro-1.1
+            value: flux-pro
           size:
             type: mixed
             value: 1920x1080
@@ -367,7 +367,7 @@ workflow:
             value: 'Extract SCENE 2 IMAGE_PROMPT from: {{#storyboard_llm.text#}}'
           model:
             type: mixed
-            value: flux-pro-1.1
+            value: flux-pro
           size:
             type: mixed
             value: 1920x1080
@@ -400,7 +400,7 @@ workflow:
             value: 'Extract SCENE 3 IMAGE_PROMPT from: {{#storyboard_llm.text#}}'
           model:
             type: mixed
-            value: flux-pro-1.1
+            value: flux-pro
           size:
             type: mixed
             value: 1920x1080
@@ -433,7 +433,7 @@ workflow:
             value: 'Extract SCENE 4 IMAGE_PROMPT from: {{#storyboard_llm.text#}}'
           model:
             type: mixed
-            value: flux-pro-1.1
+            value: flux-pro
           size:
             type: mixed
             value: 1920x1080

--- a/api/workflows/image-engine-compare.yml
+++ b/api/workflows/image-engine-compare.yml
@@ -218,7 +218,7 @@ workflow:
               value: "{{#prompt_optimizer.text#}}"
             model:
               type: mixed
-              value: flux-pro-1.1
+              value: flux-pro
         height: 90
         id: flux_gen
         position:

--- a/api/workflows/social-media-creator.yml
+++ b/api/workflows/social-media-creator.yml
@@ -283,7 +283,7 @@ workflow:
             value: '{{#article_writer.text#}}'
           model:
             type: mixed
-            value: flux-pro-1.1
+            value: flux-pro
           size:
             type: mixed
             value: 1920x1080

--- a/plugins/flux/tools/flux_generate.yaml
+++ b/plugins/flux/tools/flux_generate.yaml
@@ -64,14 +64,16 @@ parameters:
         label: { en_US: flux-dev (default), zh_Hans: flux-dev（默认） }
       - value: flux-pro
         label: { en_US: flux-pro, zh_Hans: flux-pro }
-      - value: flux-pro-1.1
-        label: { en_US: flux-pro-1.1, zh_Hans: flux-pro-1.1 }
-      - value: flux-pro-1.1-ultra
-        label: { en_US: flux-pro-1.1-ultra, zh_Hans: flux-pro-1.1-ultra }
       - value: flux-kontext-pro
         label: { en_US: flux-kontext-pro, zh_Hans: flux-kontext-pro }
       - value: flux-kontext-max
         label: { en_US: flux-kontext-max, zh_Hans: flux-kontext-max }
+      - value: flux-2-flex
+        label: { en_US: flux-2-flex, zh_Hans: flux-2-flex }
+      - value: flux-2-pro
+        label: { en_US: flux-2-pro, zh_Hans: flux-2-pro }
+      - value: flux-2-max
+        label: { en_US: flux-2-max, zh_Hans: flux-2-max }
   - name: size
     type: string
     required: false


### PR DESCRIPTION
Drop `flux-pro-1.1` / `flux-pro-1.1-ultra` from the Flux Dify tool plugin and add the **Flux 2** family in their place. Also swap all hardcoded `flux-pro-1.1` references in the seeded workflow templates to `flux-pro` (no Flux 2 default chosen for templates so existing users don't see surprise price jumps).

### Why
The old openai-hk Flux channel is dead (all 6 models 500). Migrating to TTApi, which carries Flux 2 but not the legacy `flux-pro-1.1*` SKUs.

### Final lineup (7 models)
`flux-dev`, `flux-pro`, `flux-kontext-pro`, `flux-kontext-max`, `flux-2-flex`, `flux-2-pro`, `flux-2-max`

### Files
- `plugins/flux/tools/flux_generate.yaml` — model options
- `api/workflows/ai-logo-designer.yml`
- `api/workflows/ai-marketing-suite.yml`
- `api/workflows/ai-storyboard-video.yml`
- `api/workflows/image-engine-compare.yml`
- `api/workflows/social-media-creator.yml`

### Companion PRs
- PlatformService: AceDataCloud/PlatformService#954
- Nexior: AceDataCloud/Nexior#833
- MCPs: AceDataCloud/MCPs#353