### PR TITLE
feat(plugins/suno): support inspo (灵感创作) action

### DIFF
--- a/plugins/suno/tools/suno_generate_audios.py
+++ b/plugins/suno/tools/suno_generate_audios.py
@@ -54,6 +54,15 @@ class SunoGenerateAudiosTool(Tool):
         audio_id = tool_parameters.get("audio_id")
         audio_id = audio_id.strip() if isinstance(audio_id, str) and audio_id.strip() else None
 
+        audio_urls_raw = tool_parameters.get("audio_urls")
+        audio_urls: list[str] | None = None
+        if isinstance(audio_urls_raw, str) and audio_urls_raw.strip():
+            audio_urls = [u.strip() for u in audio_urls_raw.split(",") if u.strip()]
+        elif isinstance(audio_urls_raw, list):
+            audio_urls = [str(u).strip() for u in audio_urls_raw if str(u).strip()]
+        if audio_urls is not None and not audio_urls:
+            audio_urls = None
+
         continue_at = parse_optional_float(tool_parameters.get("continue_at"), field="continue_at")
         audio_weight = parse_optional_float(tool_parameters.get("audio_weight"), field="audio_weight")
 
@@ -88,7 +97,10 @@ class SunoGenerateAudiosTool(Tool):
             else None
         )
 
-        if custom is True:
+        if action == "inspo":
+            if not audio_urls or not 1 <= len(audio_urls) <= 4:
+                raise ValueError("`audio_urls` must contain 1 to 4 reference audio URLs when action is inspo.")
+        elif custom is True:
             if not lyric and not lyric_prompt and not instrumental:
                 raise ValueError("When `custom` is true, provide `lyric` or `lyric_prompt` (unless instrumental).")
         else:
@@ -131,6 +143,8 @@ class SunoGenerateAudiosTool(Tool):
             payload["style_negative"] = style_negative
         if audio_id:
             payload["audio_id"] = audio_id
+        if audio_urls:
+            payload["audio_urls"] = audio_urls
         if continue_at is not None:
             payload["continue_at"] = continue_at
         if audio_weight is not None:

--- a/plugins/suno/tools/suno_generate_audios.yaml
+++ b/plugins/suno/tools/suno_generate_audios.yaml
@@ -32,9 +32,9 @@ parameters:
     required: true
     label: { en_US: Action, zh_Hans: 行为 }
     human_description:
-      en_US: Generation action, e.g. generate/extend/cover/stems/all_stems/concat/remaster/mashup/replace_section/underpainting/overpainting/samples.
-      zh_Hans: 生成行为，如 generate/extend/cover/stems/all_stems/concat/remaster/mashup/replace_section/underpainting/overpainting/samples。
-    llm_description: Required. Typical values are generate, extend, upload_extend, cover, upload_cover, stems, all_stems, concat, remaster, artist_consistency, artist_consistency_vox, replace_section, underpainting, overpainting, mashup, samples.
+      en_US: Generation action, e.g. generate/extend/cover/stems/all_stems/concat/remaster/mashup/replace_section/underpainting/overpainting/samples/inspo.
+      zh_Hans: 生成行为，如 generate/extend/cover/stems/all_stems/concat/remaster/mashup/replace_section/underpainting/overpainting/samples/inspo。
+    llm_description: Required. Typical values are generate, extend, upload_extend, cover, upload_cover, stems, all_stems, concat, remaster, artist_consistency, artist_consistency_vox, replace_section, underpainting, overpainting, mashup, samples, inspo. Use inspo to generate new music inspired by 1-4 reference audios (requires audio_urls).
     form: form
   - name: prompt
     type: string
@@ -108,6 +108,15 @@ parameters:
       en_US: Required for extend/cover/stems/all_stems/concat/remaster and other edit actions.
       zh_Hans: extend/cover/stems/all_stems/concat/remaster 等编辑动作必填。
     form: form
+  - name: audio_urls
+    type: string
+    required: false
+    label: { en_US: Reference Audio URLs, zh_Hans: 参考音频URL }
+    human_description:
+      en_US: Required when action is inspo. 1 to 4 public audio URLs used as inspiration, comma-separated.
+      zh_Hans: action 为 inspo 时必填。1 到 4 个公开音频 URL 作为灵感来源，使用英文逗号分隔。
+    llm_description: Required when action is inspo. A comma-separated list of 1 to 4 publicly accessible reference audio URLs.
+    form: llm
   - name: continue_at
     type: number
     required: false


### PR DESCRIPTION
Adds `audio_urls` to the Suno audios Dify plugin tool so the new `action=inspo` works: generate new music inspired by 1–4 public reference audio URLs (comma-separated). Reuses the existing generic audios tool (the plugin's convention) rather than adding a separate tool. Validation requires 1–4 urls and exempts inspo from the prompt-required rule.

Pairs with PlatformService#1032, PlatformBackend#692, MCPs#396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)