### PR TITLE
feat(kling): expose canonical Omni references

### DIFF
--- a/plugins/kling/provider/kling.py
+++ b/plugins/kling/provider/kling.py
@@ -12,7 +12,9 @@ class KlingProvider(ToolProvider):
     def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         token = credentials.get("acedata_bearer_token")
         if not isinstance(token, str) or not token.strip():
-            raise ToolProviderCredentialValidationError("Missing `acedata_bearer_token`.")
+            raise ToolProviderCredentialValidationError(
+                "Missing `acedata_bearer_token`."
+            )
 
         client = AceDataKlingClient(bearer_token=token)
         try:
@@ -29,4 +31,6 @@ class KlingProvider(ToolProvider):
             if isinstance(e, AceDataKlingError):
                 raise ToolProviderCredentialValidationError(str(e)) from e
 
-            raise ToolProviderCredentialValidationError(f"Credential validation failed: {e!s}") from e
+            raise ToolProviderCredentialValidationError(
+                f"Credential validation failed: {e!s}"
+            ) from e

--- a/plugins/kling/tests/test_acedata_client.py
+++ b/plugins/kling/tests/test_acedata_client.py
@@ -1,0 +1,205 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tools.acedata_client import (
+    AceDataKlingClient,
+    parse_camera_control,
+    parse_reference_list,
+    validate_video_request,
+)
+
+
+def test_generate_video_forwards_sanitized_omni_references() -> None:
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {"success": True, "task_id": "task-1"}
+
+    with patch("tools.acedata_client.requests.post", return_value=response) as post:
+        result = AceDataKlingClient("token", "https://example.com").generate_video(
+            action="text2video",
+            model="kling-o1",
+            prompt="Use <<<image_1>>>",
+            duration=5,
+            image_list=[{"image_url": "https://example.com/ref.jpg"}],
+            video_list=[
+                {
+                    "video_url": "https://example.com/ref.mp4",
+                    "refer_type": "feature",
+                    "keep_original_sound": "yes",
+                }
+            ],
+        )
+
+    assert result.task_id == "task-1"
+    assert post.call_args.kwargs["json"]["model"] == "kling-o1"
+    assert post.call_args.kwargs["json"]["image_list"] == [
+        {"image_url": "https://example.com/ref.jpg"}
+    ]
+    assert post.call_args.kwargs["json"]["video_list"][0]["refer_type"] == "feature"
+
+
+def test_generate_video_forwards_async_without_callback() -> None:
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {"success": True, "task_id": "task-async"}
+
+    with patch("tools.acedata_client.requests.post", return_value=response) as post:
+        AceDataKlingClient("token", "https://example.com").generate_video(
+            action="text2video",
+            model="kling-v3",
+            prompt="test",
+            async_mode=True,
+        )
+
+    assert post.call_args.kwargs["json"]["async"] is True
+    assert "callback_url" not in post.call_args.kwargs["json"]
+
+
+def test_reference_parser_rejects_unknown_fields() -> None:
+    with pytest.raises(ValueError, match="Unsupported `image_list` fields"):
+        parse_reference_list(
+            '[{"image_url":"https://example.com/ref.jpg","element_id":"unsafe"}]',
+            field_name="image_list",
+            allowed_keys={"image_url", "type"},
+        )
+    with pytest.raises(ValueError, match="must contain valid JSON"):
+        parse_reference_list(
+            '[{"image_url": invalid}]',
+            field_name="image_list",
+            allowed_keys={"image_url", "type"},
+        )
+    with pytest.raises(ValueError, match="must contain valid JSON"):
+        parse_camera_control('{"type": invalid}')
+
+
+def test_contract_rejects_legacy_model_and_invalid_combinations() -> None:
+    with pytest.raises(ValueError, match="Unsupported Kling model"):
+        validate_video_request(
+            action="text2video",
+            model="unknown-kling-model",
+            mode="std",
+            duration=5,
+            start_image_url=None,
+            end_image_url=None,
+            negative_prompt=None,
+            camera_control=None,
+            cfg_scale=None,
+            image_list=[],
+            video_list=[],
+            generate_audio=None,
+        )
+
+    with pytest.raises(ValueError, match="does not support generate_audio"):
+        validate_video_request(
+            action="text2video",
+            model="kling-o1",
+            mode="std",
+            duration=5,
+            start_image_url=None,
+            end_image_url=None,
+            negative_prompt=None,
+            camera_control=None,
+            cfg_scale=None,
+            image_list=[],
+            video_list=[{"video_url": "https://example.com/ref.mp4"}],
+            generate_audio=True,
+        )
+
+
+def test_contract_rejects_invalid_reference_items_and_o1_controls() -> None:
+    common = {
+        "action": "text2video",
+        "model": "kling-o1",
+        "mode": "std",
+        "duration": 5,
+        "start_image_url": None,
+        "end_image_url": None,
+        "negative_prompt": None,
+        "camera_control": None,
+        "cfg_scale": None,
+        "image_list": [],
+        "video_list": [],
+        "generate_audio": None,
+    }
+
+    with pytest.raises(ValueError, match="does not support generate_audio"):
+        validate_video_request(**{**common, "generate_audio": True})
+    with pytest.raises(ValueError, match="kling-o1.*does not support"):
+        validate_video_request(**{**common, "cfg_scale": 0.5})
+    with pytest.raises(ValueError, match="requires an HTTP image_url"):
+        validate_video_request(
+            **{
+                **common,
+                "image_list": [{"image_url": "file:///tmp/ref.jpg"}],
+            }
+        )
+    with pytest.raises(ValueError, match="start_image_url.*HTTP URL"):
+        validate_video_request(
+            **{
+                **common,
+                "start_image_url": "file:///tmp/start.jpg",
+            }
+        )
+
+
+def test_contract_rejects_legacy_model_limits_and_extend_references() -> None:
+    common = {
+        "action": "text2video",
+        "model": "kling-v1",
+        "mode": "std",
+        "duration": 5,
+        "start_image_url": None,
+        "end_image_url": None,
+        "negative_prompt": None,
+        "camera_control": None,
+        "cfg_scale": None,
+        "image_list": [],
+        "video_list": [],
+        "generate_audio": None,
+    }
+
+    with pytest.raises(ValueError, match="only 5- or 10-second"):
+        validate_video_request(**{**common, "duration": 6})
+    with pytest.raises(ValueError, match="4k mode requires"):
+        validate_video_request(**{**common, "mode": "4k"})
+    with pytest.raises(ValueError, match="generate_audio.*requires"):
+        validate_video_request(**{**common, "generate_audio": True})
+    with pytest.raises(ValueError, match="only in pro mode"):
+        validate_video_request(
+            **{
+                **common,
+                "model": "kling-v2-6",
+                "generate_audio": True,
+            }
+        )
+    with pytest.raises(ValueError, match="not supported with extend"):
+        validate_video_request(
+            **{
+                **common,
+                "action": "extend",
+                "image_list": [{"image_url": "https://example.com/ref.jpg"}],
+            }
+        )
+    with pytest.raises(ValueError, match="extend requires"):
+        validate_video_request(
+            **{
+                **common,
+                "action": "extend",
+                "model": "kling-o1",
+            }
+        )
+    with pytest.raises(ValueError, match="at most one first_frame"):
+        validate_video_request(
+            **{
+                **common,
+                "model": "kling-v3-omni",
+                "start_image_url": "https://example.com/start.jpg",
+                "image_list": [
+                    {
+                        "image_url": "https://example.com/other-start.jpg",
+                        "type": "first_frame",
+                    }
+                ],
+            }
+        )

--- a/plugins/kling/tools/acedata_client.py
+++ b/plugins/kling/tools/acedata_client.py
@@ -2,8 +2,27 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlparse
 
 import requests
+
+
+KLING_MODELS = {
+    "kling-v1",
+    "kling-v1-6",
+    "kling-v2-master",
+    "kling-v2-1-master",
+    "kling-v2-5-turbo",
+    "kling-v2-6",
+    "kling-v3",
+    "kling-v3-omni",
+    "kling-o1",
+}
+KLING_OMNI_MODELS = {"kling-v3-omni", "kling-o1"}
+
+
+def _is_http_url(value: Any) -> bool:
+    return isinstance(value, str) and urlparse(value).scheme in {"http", "https"}
 
 
 @dataclass(frozen=True)
@@ -48,7 +67,9 @@ def _normalize_token(raw_token: str) -> str:
 
 
 class AceDataKlingClient:
-    def __init__(self, bearer_token: str, base_url: str = "https://api.acedata.cloud") -> None:
+    def __init__(
+        self, bearer_token: str, base_url: str = "https://api.acedata.cloud"
+    ) -> None:
         token = _normalize_token(bearer_token)
         if not token:
             raise AceDataKlingError(code="token_empty", message="Empty bearer token.")
@@ -68,8 +89,10 @@ class AceDataKlingClient:
         negative_prompt: str | None = None,
         aspect_ratio: str | None = None,
         duration: int | None = None,
-        camera_control: str | dict[str, Any] | None = None,
+        camera_control: dict[str, Any] | None = None,
         cfg_scale: float | None = None,
+        image_list: list[dict[str, Any]] | None = None,
+        video_list: list[dict[str, Any]] | None = None,
         callback_url: str | None = None,
         async_mode: bool | None = None,
         video_id: str | None = None,
@@ -98,10 +121,14 @@ class AceDataKlingClient:
             payload["camera_control"] = camera_control
         if cfg_scale is not None:
             payload["cfg_scale"] = cfg_scale
+        if image_list:
+            payload["image_list"] = image_list
+        if video_list:
+            payload["video_list"] = video_list
         if callback_url:
             payload["callback_url"] = callback_url
-            if async_mode:
-                payload["async"] = True
+        if async_mode:
+            payload["async"] = True
         if video_id:
             payload["video_id"] = video_id
         if mirror is not None:
@@ -109,14 +136,22 @@ class AceDataKlingClient:
         if generate_audio is not None:
             payload["generate_audio"] = generate_audio
 
-        body = self._post_json(path="/kling/videos", payload=payload, timeout_s=timeout_s)
+        body = self._post_json(
+            path="/kling/videos", payload=payload, timeout_s=timeout_s
+        )
         return AceDataKlingVideosResult(
-            task_id=body.get("task_id") if isinstance(body.get("task_id"), str) else None,
-            trace_id=body.get("trace_id") if isinstance(body.get("trace_id"), str) else None,
+            task_id=body.get("task_id")
+            if isinstance(body.get("task_id"), str)
+            else None,
+            trace_id=body.get("trace_id")
+            if isinstance(body.get("trace_id"), str)
+            else None,
             data=body,
         )
 
-    def _post_json(self, *, path: str, payload: dict[str, Any], timeout_s: int) -> dict[str, Any]:
+    def _post_json(
+        self, *, path: str, payload: dict[str, Any], timeout_s: int
+    ) -> dict[str, Any]:
         url = f"{self._base_url}{path}"
         headers = {
             "authorization": f"Bearer {self._token}",
@@ -147,10 +182,14 @@ class AceDataKlingClient:
             )
 
         if resp.status_code >= 400:
-            trace_id = body.get("trace_id") if isinstance(body.get("trace_id"), str) else None
+            trace_id = (
+                body.get("trace_id") if isinstance(body.get("trace_id"), str) else None
+            )
             error = body.get("error") if isinstance(body.get("error"), dict) else {}
             code = error.get("code") if isinstance(error.get("code"), str) else None
-            message = error.get("message") if isinstance(error.get("message"), str) else None
+            message = (
+                error.get("message") if isinstance(error.get("message"), str) else None
+            )
             raise AceDataKlingError(
                 code=code or "error",
                 message=message or str(body),
@@ -159,10 +198,14 @@ class AceDataKlingClient:
             )
 
         if "success" in body and body.get("success") is not True:
-            trace_id = body.get("trace_id") if isinstance(body.get("trace_id"), str) else None
+            trace_id = (
+                body.get("trace_id") if isinstance(body.get("trace_id"), str) else None
+            )
             error = body.get("error") if isinstance(body.get("error"), dict) else {}
             code = error.get("code") if isinstance(error.get("code"), str) else None
-            message = error.get("message") if isinstance(error.get("message"), str) else None
+            message = (
+                error.get("message") if isinstance(error.get("message"), str) else None
+            )
             raise AceDataKlingError(
                 code=code or "api_error",
                 message=message or str(body),
@@ -173,7 +216,7 @@ class AceDataKlingClient:
         return body
 
 
-def parse_camera_control(value: Any) -> str | dict[str, Any] | None:
+def parse_camera_control(value: Any) -> dict[str, Any] | None:
     if value is None:
         return None
     if isinstance(value, dict):
@@ -185,9 +228,186 @@ def parse_camera_control(value: Any) -> str | dict[str, Any] | None:
         if text.startswith("{"):
             import json
 
-            loaded = json.loads(text)
+            try:
+                loaded = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError("`camera_control` must contain valid JSON.") from exc
             if not isinstance(loaded, dict):
-                raise ValueError("`camera_control` must be a JSON object or a plain string.")
+                raise ValueError("`camera_control` must be a JSON object.")
             return loaded
-        return text
-    raise ValueError("`camera_control` must be a JSON object or a string.")
+        raise ValueError("`camera_control` must be a JSON object.")
+    raise ValueError("`camera_control` must be an object or a JSON object string.")
+
+
+def parse_reference_list(
+    value: Any,
+    *,
+    field_name: str,
+    allowed_keys: set[str],
+) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        import json
+
+        try:
+            value = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"`{field_name}` must contain valid JSON.") from exc
+    if not isinstance(value, list):
+        raise ValueError(f"`{field_name}` must be an array of objects.")
+
+    result: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise ValueError(f"Every `{field_name}` item must be an object.")
+        unknown = set(item) - allowed_keys
+        if unknown:
+            raise ValueError(
+                f"Unsupported `{field_name}` fields: {', '.join(sorted(unknown))}."
+            )
+        result.append(dict(item))
+    return result
+
+
+def validate_video_request(
+    *,
+    action: str,
+    model: str | None,
+    mode: str | None,
+    duration: int | None,
+    start_image_url: str | None,
+    end_image_url: str | None,
+    negative_prompt: str | None,
+    camera_control: dict[str, Any] | None,
+    cfg_scale: float | None,
+    image_list: list[dict[str, Any]],
+    video_list: list[dict[str, Any]],
+    generate_audio: bool | None,
+) -> None:
+    if action not in {"text2video", "image2video", "extend"}:
+        raise ValueError("`action` must be text2video, image2video, or extend.")
+    if model is None:
+        raise ValueError("`model` is required.")
+    if model not in KLING_MODELS:
+        raise ValueError(f"Unsupported Kling model: {model}.")
+    if mode is not None and mode not in {"std", "pro", "4k"}:
+        raise ValueError("`mode` must be std, pro, or 4k.")
+    if cfg_scale is not None and not 0 <= cfg_scale <= 1:
+        raise ValueError("`cfg_scale` must be between 0 and 1.")
+    if (
+        model in {"kling-v3", "kling-v3-omni"}
+        and duration is not None
+        and not 3 <= duration <= 15
+    ):
+        raise ValueError(
+            "Kling V3 models support integer durations from 3 to 15 seconds."
+        )
+    if model == "kling-o1" and duration not in {None, 5}:
+        raise ValueError("`kling-o1` supports only 5-second generation.")
+    if model == "kling-o1" and mode not in {None, "std", "pro"}:
+        raise ValueError("`kling-o1` supports only std and pro modes.")
+    if model not in {"kling-v3", "kling-v3-omni", "kling-o1"} and duration not in {
+        None,
+        5,
+        10,
+    }:
+        raise ValueError("This Kling model supports only 5- or 10-second generation.")
+    if mode == "4k" and model not in {"kling-v3", "kling-v3-omni"}:
+        raise ValueError("4k mode requires `kling-v3` or `kling-v3-omni`.")
+    if action == "extend" and model not in {
+        "kling-v1",
+        "kling-v1-6",
+        "kling-v2-5-turbo",
+    }:
+        raise ValueError("extend requires kling-v1, kling-v1-6, or kling-v2-5-turbo.")
+    if action == "extend" and (image_list or video_list):
+        raise ValueError("`image_list` and `video_list` are not supported with extend.")
+    if model == "kling-o1" and generate_audio:
+        raise ValueError("`kling-o1` does not support generate_audio.")
+    if generate_audio and model not in {"kling-v3", "kling-v3-omni", "kling-v2-6"}:
+        raise ValueError(
+            "`generate_audio` requires a V3 model or `kling-v2-6` pro mode."
+        )
+    if generate_audio and model == "kling-v2-6" and mode != "pro":
+        raise ValueError("`kling-v2-6` supports generate_audio only in pro mode.")
+    if end_image_url and not start_image_url:
+        raise ValueError("`start_image_url` is required with `end_image_url`.")
+    if start_image_url is not None and not _is_http_url(start_image_url):
+        raise ValueError("`start_image_url` must be an HTTP URL.")
+    if end_image_url is not None and not _is_http_url(end_image_url):
+        raise ValueError("`end_image_url` must be an HTTP URL.")
+
+    references = bool(image_list or video_list)
+    if references and model not in KLING_OMNI_MODELS:
+        raise ValueError(
+            "`image_list` and `video_list` require `kling-o1` or `kling-v3-omni`."
+        )
+    if references and mode == "4k":
+        raise ValueError("4k cannot be combined with Omni references.")
+    if model == "kling-o1" and (
+        negative_prompt is not None
+        or camera_control is not None
+        or cfg_scale is not None
+    ):
+        raise ValueError(
+            "`kling-o1` does not support negative_prompt, camera_control, or cfg_scale."
+        )
+    if references and (
+        negative_prompt is not None
+        or camera_control is not None
+        or cfg_scale is not None
+    ):
+        raise ValueError(
+            "Omni references cannot be combined with negative_prompt, camera_control, or cfg_scale."
+        )
+    if video_list and generate_audio:
+        raise ValueError("`generate_audio` cannot be combined with `video_list`.")
+    if len(video_list) > 1:
+        raise ValueError("`video_list` accepts at most one video.")
+
+    for image in image_list:
+        image_url = image.get("image_url")
+        if not _is_http_url(image_url):
+            raise ValueError("Every image_list item requires an HTTP image_url.")
+        if image.get("type") not in {None, "first_frame", "end_frame"}:
+            raise ValueError("image_list type must be first_frame or end_frame.")
+    for video in video_list:
+        video_url = video.get("video_url")
+        if not _is_http_url(video_url):
+            raise ValueError("Every video_list item requires an HTTP video_url.")
+        if video.get("refer_type") not in {None, "base", "feature"}:
+            raise ValueError("video_list refer_type must be base or feature.")
+        if video.get("keep_original_sound") not in {None, "yes", "no"}:
+            raise ValueError("video_list keep_original_sound must be yes or no.")
+
+    first_frames = int(bool(start_image_url)) + sum(
+        item.get("type") == "first_frame" for item in image_list
+    )
+    end_frames = int(bool(end_image_url)) + sum(
+        item.get("type") == "end_frame" for item in image_list
+    )
+    if first_frames > 1 or end_frames > 1:
+        raise ValueError(
+            "`image_list` accepts at most one first_frame and one end_frame."
+        )
+    if end_frames and not first_frames:
+        raise ValueError("An image_list end_frame requires a first frame.")
+    if (
+        video_list
+        and video_list[0].get("refer_type", "base") == "base"
+        and (first_frames or end_frames)
+    ):
+        raise ValueError(
+            "A base reference video cannot be combined with first or end frames."
+        )
+
+    image_count = len(image_list) + bool(start_image_url) + bool(end_image_url)
+    image_limit = 4 if video_list else 7
+    if image_count > image_limit:
+        raise ValueError(
+            f"Reference images cannot exceed {image_limit} for this request."
+        )

--- a/plugins/kling/tools/kling_generate.py
+++ b/plugins/kling/tools/kling_generate.py
@@ -10,6 +10,8 @@ from tools.acedata_client import (
     AceDataKlingClient,
     AceDataKlingError,
     parse_camera_control,
+    parse_reference_list,
+    validate_video_request,
 )
 
 
@@ -63,6 +65,8 @@ class KlingGenerateVideoTool(Tool):
         if duration is not None:
             if isinstance(duration, bool) or not isinstance(duration, (int, float)):
                 raise ValueError("`duration` must be a number.")
+            if isinstance(duration, float) and not duration.is_integer():
+                raise ValueError("`duration` must be an integer.")
             duration = int(duration)
 
         cfg_scale = tool_parameters.get("cfg_scale")
@@ -72,6 +76,16 @@ class KlingGenerateVideoTool(Tool):
             cfg_scale = float(cfg_scale)
 
         camera_control = parse_camera_control(tool_parameters.get("camera_control"))
+        image_list = parse_reference_list(
+            tool_parameters.get("image_list"),
+            field_name="image_list",
+            allowed_keys={"image_url", "type"},
+        )
+        video_list = parse_reference_list(
+            tool_parameters.get("video_list"),
+            field_name="video_list",
+            allowed_keys={"video_url", "refer_type", "keep_original_sound"},
+        )
 
         callback_url = tool_parameters.get("callback_url")
         callback_url = (
@@ -81,7 +95,9 @@ class KlingGenerateVideoTool(Tool):
         )
 
         video_id = tool_parameters.get("video_id")
-        video_id = video_id.strip() if isinstance(video_id, str) and video_id.strip() else None
+        video_id = (
+            video_id.strip() if isinstance(video_id, str) and video_id.strip() else None
+        )
 
         mirror = tool_parameters.get("mirror")
         if mirror is not None and not isinstance(mirror, bool):
@@ -92,11 +108,30 @@ class KlingGenerateVideoTool(Tool):
             raise ValueError("`generate_audio` must be a boolean.")
 
         if action in {"text2video", "image2video", "extend"} and not prompt:
-            raise ValueError("`prompt` is required when action is text2video/image2video/extend.")
+            raise ValueError(
+                "`prompt` is required when action is text2video/image2video/extend."
+            )
         if action == "image2video" and not start_image_url:
-            raise ValueError("`start_image_url` is required when action is image2video.")
+            raise ValueError(
+                "`start_image_url` is required when action is image2video."
+            )
         if action == "extend" and not video_id:
             raise ValueError("`video_id` is required when action is extend.")
+
+        validate_video_request(
+            action=action,
+            model=model,
+            mode=mode,
+            duration=duration,
+            start_image_url=start_image_url,
+            end_image_url=end_image_url,
+            negative_prompt=negative_prompt,
+            camera_control=camera_control,
+            cfg_scale=cfg_scale,
+            image_list=image_list,
+            video_list=video_list,
+            generate_audio=generate_audio,
+        )
 
         client = AceDataKlingClient(
             bearer_token=str(self.runtime.credentials["acedata_bearer_token"])
@@ -114,6 +149,8 @@ class KlingGenerateVideoTool(Tool):
                 duration=duration,
                 camera_control=camera_control,
                 cfg_scale=cfg_scale,
+                image_list=image_list,
+                video_list=video_list,
                 callback_url=callback_url,
                 async_mode=bool(tool_parameters.get("async")),
                 video_id=video_id,

--- a/plugins/kling/tools/kling_generate.yaml
+++ b/plugins/kling/tools/kling_generate.yaml
@@ -94,14 +94,14 @@ parameters:
     form: form
   - name: model
     type: string
-    required: false
+    required: true
     label:
       en_US: Model
       zh_Hans: 模型
     human_description:
-      en_US: Optional model name (e.g., kling-v3, kling-v3-omni, kling-v2-6, kling-v2-master).
-      zh_Hans: 可选模型名称（如 kling-v3、kling-v3-omni、kling-v2-6、kling-v2-master）。
-    llm_description: "Optional. Examples: kling-v1, kling-v1-6, kling-v2-master, kling-v2-1-master, kling-v2-5-turbo, kling-v2-6, kling-v3, kling-v3-omni, kling-video-o1."
+      en_US: Required model name (e.g., kling-v3, kling-v3-omni, kling-v2-6, kling-o1).
+      zh_Hans: 必填模型名称（如 kling-v3、kling-v3-omni、kling-v2-6、kling-o1）。
+    llm_description: "Required. Choose one of kling-v1, kling-v1-6, kling-v2-master, kling-v2-1-master, kling-v2-5-turbo, kling-v2-6, kling-v3, kling-v3-omni, or kling-o1."
     form: form
   - name: mode
     type: select
@@ -112,13 +112,15 @@ parameters:
     human_description:
       en_US: Optional generation mode.
       zh_Hans: 可选生成模式。
-    llm_description: Optional. std for standard, pro for fast.
+    llm_description: Optional. std for standard, pro for fast, or 4k only for kling-v3/kling-v3-omni without Omni references.
     form: form
     options:
       - value: std
         label: { en_US: std, zh_Hans: 标准 }
       - value: pro
         label: { en_US: pro, zh_Hans: 极速 }
+      - value: 4k
+        label: { en_US: 4k, zh_Hans: 4K }
   - name: duration
     type: number
     required: false
@@ -126,9 +128,9 @@ parameters:
       en_US: Duration
       zh_Hans: 时长
     human_description:
-      en_US: Optional duration in seconds. For kling-v3/kling-v3-omni 3-15 (integer). Other models 5 or 10.
-      zh_Hans: 可选视频时长。kling-v3/kling-v3-omni 支持 3-15 秒整数，其他模型支持 5 或 10。
-    llm_description: Optional. For kling-v3/kling-v3-omni use integer 3-15. For other models use 5 or 10.
+      en_US: Optional duration in seconds. V3 models support integers 3-15; kling-o1 supports 5; other models support 5 or 10.
+      zh_Hans: 可选视频时长。V3 模型支持 3-15 秒整数，kling-o1 仅支持 5 秒，其他模型支持 5 或 10 秒。
+    llm_description: Optional. V3 models use integer 3-15; kling-o1 uses 5; other models use 5 or 10.
     form: form
   - name: aspect_ratio
     type: select
@@ -166,10 +168,32 @@ parameters:
       en_US: Camera control
       zh_Hans: 相机控制
     human_description:
-      en_US: Optional camera motion control (string or JSON object string).
-      zh_Hans: 可选相机运动控制（字符串或 JSON 对象字符串）。
-    llm_description: Optional. Provide a preset string, or a JSON object string for detailed control.
+      en_US: Optional camera motion control as a JSON object string.
+      zh_Hans: 可选相机运动控制，使用 JSON 对象字符串。
+    llm_description: Optional. Provide a JSON object string; Omni generation does not support this field.
     form: form
+  - name: image_list
+    type: string
+    required: false
+    label:
+      en_US: Reference Images
+      zh_Hans: 参考图片
+    human_description:
+      en_US: JSON array of reference images for kling-o1 or kling-v3-omni.
+      zh_Hans: kling-o1 或 kling-v3-omni 使用的参考图片 JSON 数组。
+    llm_description: 'Optional for kling-o1 or kling-v3-omni. JSON array where each item has image_url and optional type: first_frame or end_frame. Up to 7 images, or 4 when video_list is present.'
+    form: llm
+  - name: video_list
+    type: string
+    required: false
+    label:
+      en_US: Reference Video
+      zh_Hans: 参考视频
+    human_description:
+      en_US: JSON array containing one base or feature reference video.
+      zh_Hans: 包含一个基础视频或特征参考视频的 JSON 数组。
+    llm_description: 'Optional JSON array with one item: video_url, optional refer_type (base or feature), and optional keep_original_sound (yes or no). Use only with kling-o1 or kling-v3-omni.'
+    form: llm
   - name: negative_prompt
     type: string
     required: false
@@ -224,7 +248,7 @@ parameters:
     human_description:
       en_US: Return a task_id immediately without a callback_url; poll the tasks endpoint for the result.
       zh_Hans: 立即返回 task_id，无需回调地址，通过任务查询接口轮询结果。
-    llm_description: Optional. Set true to submit asynchronously and get a task_id to poll.
+    llm_description: Optional. Set true to return a task_id immediately and poll the tasks endpoint; callback_url is not required.
     form: form
 extra:
   python:


### PR DESCRIPTION
## Summary
- expose only the canonical `kling-o1` model ID in the Dify Kling tool
- add typed and sanitized `image_list` and `video_list` forwarding for O1 and V3 Omni
- enforce model, duration, mode, audio, frame, reference, and prompt-control constraints before making a billable request
- keep Element Library inputs unsupported and reject unknown reference fields
- preserve async polling when `async=true` is used without a callback URL

## Validation
- `PYTHONPATH=plugins/kling python3 -m pytest plugins/kling/tests/test_acedata_client.py -q` (6 passed)
- `ruff check plugins/kling/tools plugins/kling/tests`
- `ruff format --check plugins/kling/tools plugins/kling/tests`
- Python compileall and YAML parse
- clean-break search: no `kling-video-o1` or Element fields

## Rollout dependency
Publish this plugin only after the gated worker, canonical PlatformBackend billing/OpenAPI, and live API canary are complete.

## Adversarial review
Independent read-only review converged in 3 rounds:
- fixed async requests silently becoming synchronous without `callback_url`
- converted malformed reference/camera JSON into actionable validation errors
- aligned frame URL validation and split O1 versus Omni-reference errors
- final verdict: CLEAN
