### PR TITLE
chore(dify): disable production workloads

### DIFF
--- a/deploy/production/deployment/dify-api.yml
+++ b/deploy/production/deployment/dify-api.yml
@@ -9,7 +9,7 @@ metadata:
 spec:
   minReadySeconds: 10
   progressDeadlineSeconds: 600
-  replicas: 2
+  replicas: 0
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/deploy/production/deployment/dify-nginx.yml
+++ b/deploy/production/deployment/dify-nginx.yml
@@ -7,7 +7,7 @@ metadata:
   namespace: acedatacloud
 spec:
   progressDeadlineSeconds: 600
-  replicas: 1
+  replicas: 0
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/deploy/production/deployment/dify-plugin-daemon.yml
+++ b/deploy/production/deployment/dify-plugin-daemon.yml
@@ -6,7 +6,7 @@ metadata:
   name: dify-plugin-daemon
   namespace: acedatacloud
 spec:
-  replicas: 2
+  replicas: 0
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/deploy/production/deployment/dify-sandbox.yml
+++ b/deploy/production/deployment/dify-sandbox.yml
@@ -7,7 +7,7 @@ metadata:
   namespace: acedatacloud
 spec:
   progressDeadlineSeconds: 600
-  replicas: 1
+  replicas: 0
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/deploy/production/deployment/dify-web.yml
+++ b/deploy/production/deployment/dify-web.yml
@@ -7,7 +7,7 @@ metadata:
   namespace: acedatacloud
 spec:
   progressDeadlineSeconds: 600
-  replicas: 1
+  replicas: 0
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/deploy/production/deployment/dify-worker-beat.yml
+++ b/deploy/production/deployment/dify-worker-beat.yml
@@ -6,7 +6,7 @@ metadata:
   name: dify-worker-beat
   namespace: acedatacloud
 spec:
-  replicas: 1
+  replicas: 0
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/deploy/production/deployment/dify-worker.yml
+++ b/deploy/production/deployment/dify-worker.yml
@@ -8,7 +8,7 @@ metadata:
   namespace: acedatacloud
 spec:
   progressDeadlineSeconds: 600
-  replicas: 2
+  replicas: 0
   revisionHistoryLimit: 10
   selector:
     matchLabels:


### PR DESCRIPTION
## Summary
- Set all seven Dify production Deployments to zero replicas.
- Keep Services, Secrets, ConfigMaps, PVC storage, and databases intact for reversible recovery.
- Match the production cluster, where all Dify workloads have already been scaled to zero.

## Production cleanup
- Scaled dify-api, nginx, plugin-daemon, sandbox, web, worker, and worker-beat to zero.
- Deleted 236 Failed Pods.
- Deleted 52 finished Jobs, then removed 5 additional Jobs that completed during cleanup.
- Pod objects dropped from 822 to below the L20 control-plane limit; Failed Pods are zero.

## Validation
- Parsed all seven manifests as YAML and asserted kind=Deployment and spec.replicas=0.
- git diff --check passed.
- Production Dify Deployments report 0 desired / 0 current / 0 ready.
- API server readyz passes and no Pending Pod lacks nodeName.

## 🤖 对抗评审
- Exactly seven production Deployment manifests changed; no platform-service-aichat2 or platform-service-sandbox impact.
- Persistent data and networking resources remain untouched.
- VERDICT: CLEAN