### PR TITLE
fix(seedream): remove unavailable v3 plugin options

### DIFF
--- a/plugins/seedream/README.md
+++ b/plugins/seedream/README.md
@@ -14,7 +14,7 @@ This plugin integrates **Ace Data Cloud Seedream Images API** as Dify tools for:
 ### Tools
 
 - `seedream_generate_image`
-  - Inputs: `prompt` (required), `model`, `size`, `seed`, `sequential_image_generation`, `stream`, `guidance_scale`, `response_format`, `watermark`, `callback_url`
+  - Inputs: `prompt` (required), `model`, `size`, `sequential_image_generation`, `stream`, `response_format`, `watermark`, `callback_url`
   - Outputs: `success`, `task_id`, `trace_id`, `data` (array of objects with `image_url`, optional `prompt`), `error`
 - `seedream_edit_image`
   - Inputs: `prompt` (required), `image_urls` (required), other optional params same as generate

--- a/plugins/seedream/tools/seedream_edit.py
+++ b/plugins/seedream/tools/seedream_edit.py
@@ -31,10 +31,6 @@ class SeedreamEditImageTool(Tool):
         size = tool_parameters.get("size")
         size = size.strip() if isinstance(size, str) and size.strip() else None
 
-        seed = tool_parameters.get("seed")
-        if seed is not None and not isinstance(seed, int):
-            raise ValueError("`seed` must be an integer.")
-
         sequential_image_generation = tool_parameters.get("sequential_image_generation")
         sequential_image_generation = (
             sequential_image_generation.strip()
@@ -45,10 +41,6 @@ class SeedreamEditImageTool(Tool):
         stream = tool_parameters.get("stream")
         if stream is not None and not isinstance(stream, bool):
             raise ValueError("`stream` must be a boolean.")
-
-        guidance_scale = tool_parameters.get("guidance_scale")
-        if guidance_scale is not None and not isinstance(guidance_scale, (int, float)):
-            raise ValueError("`guidance_scale` must be a number.")
 
         response_format = tool_parameters.get("response_format")
         response_format = (
@@ -73,14 +65,10 @@ class SeedreamEditImageTool(Tool):
             payload["model"] = model
         if size:
             payload["size"] = size
-        if seed is not None:
-            payload["seed"] = seed
         if sequential_image_generation:
             payload["sequential_image_generation"] = sequential_image_generation
         if stream is not None:
             payload["stream"] = stream
-        if guidance_scale is not None:
-            payload["guidance_scale"] = guidance_scale
         if response_format:
             payload["response_format"] = response_format
         if watermark is not None:

--- a/plugins/seedream/tools/seedream_edit.yaml
+++ b/plugins/seedream/tools/seedream_edit.yaml
@@ -77,6 +77,14 @@ parameters:
     llm_description: Optional. Choose a supported Seedream model.
     form: form
     options:
+      - value: doubao-seedream-5-0-pro-260628
+        label:
+          en_US: doubao-seedream-5-0-pro-260628
+          zh_Hans: doubao-seedream-5-0-pro-260628
+      - value: doubao-seedream-5-0-260128
+        label:
+          en_US: doubao-seedream-5-0-260128
+          zh_Hans: doubao-seedream-5-0-260128
       - value: doubao-seedream-4-0-250828
         label:
           en_US: doubao-seedream-4-0-250828 (default)
@@ -85,14 +93,6 @@ parameters:
         label:
           en_US: doubao-seedream-4-5-251128
           zh_Hans: doubao-seedream-4-5-251128
-      - value: doubao-seedream-3-0-t2i-250415
-        label:
-          en_US: doubao-seedream-3-0-t2i-250415
-          zh_Hans: doubao-seedream-3-0-t2i-250415
-      - value: doubao-seededit-3-0-i2i-250628
-        label:
-          en_US: doubao-seededit-3-0-i2i-250628
-          zh_Hans: doubao-seededit-3-0-i2i-250628
   - name: size
     type: select
     required: false
@@ -109,21 +109,12 @@ parameters:
         label: { en_US: 1K, zh_Hans: 1K }
       - value: 2K
         label: { en_US: 2K, zh_Hans: 2K }
+      - value: 3K
+        label: { en_US: 3K, zh_Hans: 3K }
       - value: 4K
         label: { en_US: 4K, zh_Hans: 4K }
       - value: adaptive
         label: { en_US: adaptive, zh_Hans: adaptive }
-  - name: seed
-    type: number
-    required: false
-    label:
-      en_US: Seed
-      zh_Hans: 随机种子
-    human_description:
-      en_US: Optional seed for reproducibility (supported by some models).
-      zh_Hans: 可选随机数种子（部分模型支持）。
-    llm_description: Optional. Integer only.
-    form: form
   - name: sequential_image_generation
     type: select
     required: false
@@ -131,15 +122,15 @@ parameters:
       en_US: Sequential image generation
       zh_Hans: 组图
     human_description:
-      en_US: Optional. Use disabled/enabled depending on model support.
-      zh_Hans: 可选，根据模型支持情况填写 disabled/enabled。
+      en_US: Optional. Use disabled/auto depending on model support.
+      zh_Hans: 可选，根据模型支持情况填写 disabled/auto。
     llm_description: Optional.
     form: form
     options:
       - value: disabled
         label: { en_US: disabled, zh_Hans: disabled }
-      - value: enabled
-        label: { en_US: enabled, zh_Hans: enabled }
+      - value: auto
+        label: { en_US: auto, zh_Hans: auto }
   - name: stream
     type: boolean
     required: false
@@ -149,17 +140,6 @@ parameters:
     human_description:
       en_US: Optional. Stream output (only supported by some models).
       zh_Hans: 可选，流式输出（仅部分模型支持）。
-    llm_description: Optional.
-    form: form
-  - name: guidance_scale
-    type: number
-    required: false
-    label:
-      en_US: Guidance scale
-      zh_Hans: 文本权重
-    human_description:
-      en_US: Optional prompt weight (only supported by some models).
-      zh_Hans: 可选文本权重（仅部分模型支持）。
     llm_description: Optional.
     form: form
   - name: response_format

--- a/plugins/seedream/tools/seedream_generate.py
+++ b/plugins/seedream/tools/seedream_generate.py
@@ -23,10 +23,6 @@ class SeedreamGenerateImageTool(Tool):
         size = tool_parameters.get("size")
         size = size.strip() if isinstance(size, str) and size.strip() else None
 
-        seed = tool_parameters.get("seed")
-        if seed is not None and not isinstance(seed, int):
-            raise ValueError("`seed` must be an integer.")
-
         sequential_image_generation = tool_parameters.get("sequential_image_generation")
         sequential_image_generation = (
             sequential_image_generation.strip()
@@ -37,10 +33,6 @@ class SeedreamGenerateImageTool(Tool):
         stream = tool_parameters.get("stream")
         if stream is not None and not isinstance(stream, bool):
             raise ValueError("`stream` must be a boolean.")
-
-        guidance_scale = tool_parameters.get("guidance_scale")
-        if guidance_scale is not None and not isinstance(guidance_scale, (int, float)):
-            raise ValueError("`guidance_scale` must be a number.")
 
         response_format = tool_parameters.get("response_format")
         response_format = (
@@ -65,14 +57,10 @@ class SeedreamGenerateImageTool(Tool):
             payload["model"] = model
         if size:
             payload["size"] = size
-        if seed is not None:
-            payload["seed"] = seed
         if sequential_image_generation:
             payload["sequential_image_generation"] = sequential_image_generation
         if stream is not None:
             payload["stream"] = stream
-        if guidance_scale is not None:
-            payload["guidance_scale"] = guidance_scale
         if response_format:
             payload["response_format"] = response_format
         if watermark is not None:

--- a/plugins/seedream/tools/seedream_generate.yaml
+++ b/plugins/seedream/tools/seedream_generate.yaml
@@ -62,6 +62,14 @@ parameters:
     llm_description: Optional. Choose a supported Seedream model.
     form: form
     options:
+      - value: doubao-seedream-5-0-pro-260628
+        label:
+          en_US: doubao-seedream-5-0-pro-260628
+          zh_Hans: doubao-seedream-5-0-pro-260628
+      - value: doubao-seedream-5-0-260128
+        label:
+          en_US: doubao-seedream-5-0-260128
+          zh_Hans: doubao-seedream-5-0-260128
       - value: doubao-seedream-4-0-250828
         label:
           en_US: doubao-seedream-4-0-250828 (default)
@@ -70,14 +78,6 @@ parameters:
         label:
           en_US: doubao-seedream-4-5-251128
           zh_Hans: doubao-seedream-4-5-251128
-      - value: doubao-seedream-3-0-t2i-250415
-        label:
-          en_US: doubao-seedream-3-0-t2i-250415
-          zh_Hans: doubao-seedream-3-0-t2i-250415
-      - value: doubao-seededit-3-0-i2i-250628
-        label:
-          en_US: doubao-seededit-3-0-i2i-250628
-          zh_Hans: doubao-seededit-3-0-i2i-250628
   - name: size
     type: select
     required: false
@@ -94,21 +94,12 @@ parameters:
         label: { en_US: 1K, zh_Hans: 1K }
       - value: 2K
         label: { en_US: 2K, zh_Hans: 2K }
+      - value: 3K
+        label: { en_US: 3K, zh_Hans: 3K }
       - value: 4K
         label: { en_US: 4K, zh_Hans: 4K }
       - value: adaptive
         label: { en_US: adaptive, zh_Hans: adaptive }
-  - name: seed
-    type: number
-    required: false
-    label:
-      en_US: Seed
-      zh_Hans: 随机种子
-    human_description:
-      en_US: Optional seed for reproducibility (supported by some models).
-      zh_Hans: 可选随机数种子（部分模型支持）。
-    llm_description: Optional. Integer only.
-    form: form
   - name: sequential_image_generation
     type: select
     required: false
@@ -116,15 +107,15 @@ parameters:
       en_US: Sequential image generation
       zh_Hans: 组图
     human_description:
-      en_US: Optional. Use disabled/enabled depending on model support.
-      zh_Hans: 可选，根据模型支持情况填写 disabled/enabled。
+      en_US: Optional. Use disabled/auto depending on model support.
+      zh_Hans: 可选，根据模型支持情况填写 disabled/auto。
     llm_description: Optional.
     form: form
     options:
       - value: disabled
         label: { en_US: disabled, zh_Hans: disabled }
-      - value: enabled
-        label: { en_US: enabled, zh_Hans: enabled }
+      - value: auto
+        label: { en_US: auto, zh_Hans: auto }
   - name: stream
     type: boolean
     required: false
@@ -134,17 +125,6 @@ parameters:
     human_description:
       en_US: Optional. Stream output (only supported by some models).
       zh_Hans: 可选，流式输出（仅部分模型支持）。
-    llm_description: Optional.
-    form: form
-  - name: guidance_scale
-    type: number
-    required: false
-    label:
-      en_US: Guidance scale
-      zh_Hans: 文本权重
-    human_description:
-      en_US: Optional prompt weight (only supported by some models).
-      zh_Hans: 可选文本权重（仅部分模型支持）。
     llm_description: Optional.
     form: form
   - name: response_format


### PR DESCRIPTION
## Summary
- remove unavailable Seedream 3.0 T2I and SeedEdit 3.0 from generate/edit tool forms
- add Seedream 5.0 Pro and 5.0 Lite to both tools
- remove unsupported `seed` / `guidance_scale` handling from Python payloads
- fix sequential image generation from invalid `enabled` to API-supported `auto`

## Validation
- parse every Seedream plugin YAML with PyYAML
- `python3 -m compileall -q plugins/seedream`
- `ruff check plugins/seedream`
- retired-model / retired-parameter reference scan
- `git diff --check`

## Dependency / rollout
Dify plugin sync for PlatformService / PlatformBackend Seedream v3 withdrawal.

Rollback: revert this commit.