### PR TITLE
feat(minimax): add resolution pricing controls

### DIFF
--- a/plugins/minimax/README.md
+++ b/plugins/minimax/README.md
@@ -7,7 +7,7 @@ AceDataCloud tool provider for MiniMax H3 multimodal video generation.
 - `minimax_generate_video`: generate 4–15 second video from text, 1–9 images, or 1–3 audio references
 - `minimax_task_retrieve`: retrieve task status and final video
 
-The generation tool supports 16:9 and 9:16, plus asynchronous submission and webhooks.
+The generation tool supports 768P and 2K, 16:9 and 9:16, optional AIGC watermark, asynchronous submission, and webhooks. Public pricing is $0.057143/s for 768P and $0.091429/s for 2K.
 
 ## Credential
 

--- a/plugins/minimax/tests/test_acedata_client.py
+++ b/plugins/minimax/tests/test_acedata_client.py
@@ -25,8 +25,10 @@ def test_generate_async_multimodal_payload(post: Mock):
         prompt="dance",
         image_urls=["https://a.test/image.png"],
         audio_urls=["https://a.test/audio.mp3"],
+        resolution="768P",
         ratio="9:16",
         duration=8,
+        aigc_watermark=True,
         async_mode=True,
     )
 
@@ -36,8 +38,10 @@ def test_generate_async_multimodal_payload(post: Mock):
         "prompt": "dance",
         "image_urls": ["https://a.test/image.png"],
         "audio_urls": ["https://a.test/audio.mp3"],
+        "resolution": "768P",
         "ratio": "9:16",
         "duration": 8,
+        "aigc_watermark": True,
         "async": True,
     }
 

--- a/plugins/minimax/tools/acedata_client.py
+++ b/plugins/minimax/tools/acedata_client.py
@@ -76,19 +76,26 @@ class AceDataMinimaxClient:
     def generate_video(
         self,
         *,
-        prompt: str | None = None,
+        prompt: str,
         image_urls: list[str] | None = None,
         audio_urls: list[str] | None = None,
         model: str = "minimax-h3",
+        resolution: str = "2K",
         ratio: str = "16:9",
         duration: int = 4,
+        aigc_watermark: bool = False,
         callback_url: str | None = None,
         async_mode: bool = False,
         timeout_s: int = 1800,
     ) -> AceDataMinimaxVideosResult:
-        payload: dict[str, Any] = {"model": model, "ratio": ratio, "duration": duration}
-        if prompt:
-            payload["prompt"] = prompt
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "resolution": resolution,
+            "ratio": ratio,
+            "duration": duration,
+            "aigc_watermark": aigc_watermark,
+        }
         if image_urls:
             payload["image_urls"] = image_urls
         if audio_urls:

--- a/plugins/minimax/tools/minimax_generate.py
+++ b/plugins/minimax/tools/minimax_generate.py
@@ -17,9 +17,14 @@ class MinimaxGenerateVideoTool(Tool):
         prompt = prompt_value.strip() if isinstance(prompt_value, str) and prompt_value.strip() else None
         image_urls = parse_urls(tool_parameters.get("image_urls"), field_name="image_urls", limit=9)
         audio_urls = parse_urls(tool_parameters.get("audio_urls"), field_name="audio_urls", limit=3)
-        if not prompt and not image_urls and not audio_urls:
-            raise ValueError("At least one of `prompt`, `image_urls`, or `audio_urls` is required.")
+        if not prompt:
+            raise ValueError("`prompt` is required in every generation mode.")
+        if audio_urls and not image_urls:
+            raise ValueError("`image_urls` is required when `audio_urls` is provided.")
 
+        resolution = tool_parameters.get("resolution") or "2K"
+        if resolution not in {"768P", "2K"}:
+            raise ValueError("`resolution` must be 768P or 2K.")
         ratio = tool_parameters.get("ratio") or "16:9"
         if ratio not in {"16:9", "9:16"}:
             raise ValueError("`ratio` must be 16:9 or 9:16.")
@@ -29,6 +34,10 @@ class MinimaxGenerateVideoTool(Tool):
         duration = int(duration)
         if duration < 4 or duration > 15:
             raise ValueError("`duration` must be an integer from 4 to 15.")
+
+        aigc_watermark = tool_parameters.get("aigc_watermark", False)
+        if not isinstance(aigc_watermark, bool):
+            raise TypeError("`aigc_watermark` must be a boolean.")
 
         callback_value = tool_parameters.get("callback_url")
         callback_url = callback_value.strip() if isinstance(callback_value, str) and callback_value.strip() else None
@@ -44,8 +53,10 @@ class MinimaxGenerateVideoTool(Tool):
                 prompt=prompt,
                 image_urls=image_urls or None,
                 audio_urls=audio_urls or None,
+                resolution=resolution,
                 ratio=ratio,
                 duration=duration,
+                aigc_watermark=aigc_watermark,
                 callback_url=callback_url,
                 async_mode=async_value,
                 timeout_s=1800,

--- a/plugins/minimax/tools/minimax_generate.yaml
+++ b/plugins/minimax/tools/minimax_generate.yaml
@@ -8,7 +8,7 @@ description:
   human:
     en_US: Generate MiniMax H3 video from text, images, or audio guidance.
     zh_Hans: 使用文本、图片或音频引导生成 MiniMax H3 视频。
-  llm: Generate a 4-15 second MiniMax H3 video. Audio input takes priority over images, and images take priority over prompt-only mode.
+  llm: Generate a 4-15 second MiniMax H3 video at 768P or 2K. Prompt is required; audio also requires images.
 output_schema:
   type: object
   properties:
@@ -29,12 +29,12 @@ output_schema:
 parameters:
   - name: prompt
     type: string
-    required: false
+    required: true
     label: { en_US: Prompt, zh_Hans: 提示词 }
     human_description:
-      en_US: Scene, motion, camera, and style description. Required for text-only mode.
-      zh_Hans: 场景、动作、镜头和风格描述；纯文生视频时必填。
-    llm_description: Optional with image_urls or audio_urls; otherwise required.
+      en_US: Scene, motion, camera, and style description. Required in every mode.
+      zh_Hans: 场景、动作、镜头和风格描述；所有模式必填。
+    llm_description: Required in every generation mode, max 7000 characters.
     form: llm
   - name: image_urls
     type: array
@@ -55,11 +55,24 @@ parameters:
     human_description:
       en_US: One to three public audio URLs. Enables audio-guided mode.
       zh_Hans: 1–3 个公网音频 URL；传入后使用音频引导模式。
-    llm_description: Optional one to three audio references; takes priority over image mode.
+    llm_description: Optional one to three audio references; image_urls is required when audio is used.
     form: form
     input_schema:
       type: array
       items: { type: string }
+  - name: resolution
+    type: select
+    required: false
+    default: "2K"
+    label: { en_US: Resolution, zh_Hans: 分辨率 }
+    human_description: { en_US: Output resolution., zh_Hans: 输出视频分辨率。 }
+    llm_description: Choose 768P or 2K. Default is 2K.
+    form: form
+    options:
+      - value: "768P"
+        label: { en_US: "768P", zh_Hans: "768P" }
+      - value: "2K"
+        label: { en_US: "2K", zh_Hans: "2K" }
   - name: ratio
     type: select
     required: false
@@ -82,6 +95,14 @@ parameters:
     label: { en_US: Duration, zh_Hans: 时长 }
     human_description: { en_US: Integer duration from 4 to 15 seconds., zh_Hans: 4–15 秒整数时长。 }
     llm_description: Integer from 4 to 15 seconds.
+    form: form
+  - name: aigc_watermark
+    type: boolean
+    required: false
+    default: false
+    label: { en_US: AIGC Watermark, zh_Hans: AIGC 水印 }
+    human_description: { en_US: Add an AIGC watermark., zh_Hans: 添加 AIGC 标识水印。 }
+    llm_description: Optional. Disabled by default.
     form: form
   - name: callback_url
     type: string


### PR DESCRIPTION
## Summary
- add resolution and AIGC watermark controls to MiniMax Dify generation
- require prompt and enforce image+audio constraint
- forward resolution-aware payloads and update tests/docs

## Verification
- ruff passed
- 3 client tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)