### PR TITLE
fix(minimax): remove watermark plugin option

### DIFF
--- a/plugins/minimax/tests/test_acedata_client.py
+++ b/plugins/minimax/tests/test_acedata_client.py
@@ -28,7 +28,6 @@ def test_generate_async_multimodal_payload(post: Mock):
         resolution="768P",
         ratio="9:16",
         duration=8,
-        aigc_watermark=True,
         async_mode=True,
     )
 
@@ -41,7 +40,6 @@ def test_generate_async_multimodal_payload(post: Mock):
         "resolution": "768P",
         "ratio": "9:16",
         "duration": 8,
-        "aigc_watermark": True,
         "async": True,
     }
 

--- a/plugins/minimax/tools/acedata_client.py
+++ b/plugins/minimax/tools/acedata_client.py
@@ -83,7 +83,6 @@ class AceDataMinimaxClient:
         resolution: str = "2K",
         ratio: str = "16:9",
         duration: int = 4,
-        aigc_watermark: bool = False,
         callback_url: str | None = None,
         async_mode: bool = False,
         timeout_s: int = 1800,
@@ -94,7 +93,6 @@ class AceDataMinimaxClient:
             "resolution": resolution,
             "ratio": ratio,
             "duration": duration,
-            "aigc_watermark": aigc_watermark,
         }
         if image_urls:
             payload["image_urls"] = image_urls

--- a/plugins/minimax/tools/minimax_generate.py
+++ b/plugins/minimax/tools/minimax_generate.py
@@ -35,10 +35,6 @@ class MinimaxGenerateVideoTool(Tool):
         if duration < 4 or duration > 15:
             raise ValueError("`duration` must be an integer from 4 to 15.")
 
-        aigc_watermark = tool_parameters.get("aigc_watermark", False)
-        if not isinstance(aigc_watermark, bool):
-            raise TypeError("`aigc_watermark` must be a boolean.")
-
         callback_value = tool_parameters.get("callback_url")
         callback_url = callback_value.strip() if isinstance(callback_value, str) and callback_value.strip() else None
         async_value = tool_parameters.get("async", False)
@@ -56,7 +52,6 @@ class MinimaxGenerateVideoTool(Tool):
                 resolution=resolution,
                 ratio=ratio,
                 duration=duration,
-                aigc_watermark=aigc_watermark,
                 callback_url=callback_url,
                 async_mode=async_value,
                 timeout_s=1800,

--- a/plugins/minimax/tools/minimax_generate.yaml
+++ b/plugins/minimax/tools/minimax_generate.yaml
@@ -96,14 +96,6 @@ parameters:
     human_description: { en_US: Integer duration from 4 to 15 seconds., zh_Hans: 4–15 秒整数时长。 }
     llm_description: Integer from 4 to 15 seconds.
     form: form
-  - name: aigc_watermark
-    type: boolean
-    required: false
-    default: false
-    label: { en_US: AIGC Watermark, zh_Hans: AIGC 水印 }
-    human_description: { en_US: Add an AIGC watermark., zh_Hans: 添加 AIGC 标识水印。 }
-    llm_description: Optional. Disabled by default.
-    form: form
   - name: callback_url
     type: string
     required: false


### PR DESCRIPTION
## Contract

`POST /minimax/videos` (API `64f22fd9-0efd-445e-b0b1-135682fd66d7`) no longer exposes `aigc_watermark`. After the coordinated runtime change, explicitly sending either boolean value is rejected as an unsupported field (HTTP 400), rather than silently ignored.

## Changes and validation

Removes the Dify tool schema parameter, parsing and type validation, client argument, and API payload key. Validation: YAML parsed, plugin tools compiled, and 3 plugin client tests passed.

## Dependency graph

consumer surfaces → PlatformService runtime enforcement + PlatformBackend OpenAPI/docs → generated Docs/downstream reconciliation

This consumer removal is safe to merge before the runtime/contract switch because it only stops emitting an optional field whose existing default is already `false`.

## Rollout / rollback

Release before or with the PlatformService and PlatformBackend PRs. Roll back together with the coordinated set; do not restore the parameter in only one surface.

## Out of scope

Legacy `/hailuo/videos`, billing rules, generated Docs files, and historical validation reports.

Adversarial review: not requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
